### PR TITLE
Potential fix for code scanning alert no. 1: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/wilco-actions.yml
+++ b/.github/workflows/wilco-actions.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
-          secrets: ${{ toJSON(secrets) }}
+          secrets: WILCO_ENGINE_URL=${{ secrets.WILCO_ENGINE_URL }}
 
       - name: Wilco checks
         id: Wilco


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-aubmew82/security/code-scanning/1](https://github.com/Wilcolab/Anythink-Market-aubmew82/security/code-scanning/1)

The problem is in the step that uses `oNaiPs/secrets-to-env-action@v1` (lines 26-28), where all secrets are exposed to the action via `${{ toJSON(secrets) }}`. The fix is to only pass the secrets that are needed downstream. To do this, remove the use of `toJSON(secrets)` and instead enumerate each required secret by name, for example `${{ secrets.WILCO_ENGINE_URL }}`. This minimizes secret exposure and aligns with security best practice.

For the fix:
- In `.github/workflows/wilco-actions.yml`, change the step with `oNaiPs/secrets-to-env-action@v1` (lines 26-28) so that only the needed secrets are passed.
- If only `WILCO_ENGINE_URL` is needed (as seen in line 34), adjust the secrets input to only contain this secret.
- If multiple secrets are needed, list them explicitly. 
- No changes are required for the steps that access secrets via `${{ secrets.NAME }}` directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
